### PR TITLE
Rsdev 847 upgrade tika lib

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,10 @@
 ## Changelog
 
+## 1.1.0 2026-01-26
+- switch to parent-pom 2.1.3
+- harden XML parsing to avoid XXE attacks
+- upgrade minor version of packages (commons-exec 1.3 -> 1.4.0, google.zxing 3.4.0 -> 3.5.4)
+
 ## 1.0.5 2026-01-14
 - switch to parent-pom 2.1.2 (spring 5.3.25 -> 5.3.39, commons-codec 1.11 -> 1.13)
 - update commons-compress (1.26.2 -> 1.28.0) and commons-io (2.14 -> 2.20)

--- a/pom.xml
+++ b/pom.xml
@@ -149,12 +149,12 @@
 		<dependency>
 			<groupId>com.google.zxing</groupId>
 			<artifactId>core</artifactId>
-			<version>3.4.0</version>
+			<version>3.5.4</version>
 		</dependency>
 		<dependency>
 			<groupId>com.google.zxing</groupId>
 			<artifactId>javase</artifactId>
-			<version>3.4.0</version>
+			<version>3.5.4</version>
 		</dependency>
 	</dependencies>
 

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>rspace-core-util</artifactId>
-	<version>1.0.5</version>
+	<version>1.1.0</version>
 	<name>rspace-core-util</name>
 	<description>Core utility classes</description>
 

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<artifactId>rspace-parent</artifactId>
 		<groupId>com.github.rspace-os</groupId>
-		<version>2.1.2</version>
+		<version>2.1.3</version>
 	</parent>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -56,7 +56,7 @@
 		<dependency>
 			<groupId>org.apache.commons</groupId>
 			<artifactId>commons-exec</artifactId>
-			<version>1.3</version>
+			<version>1.4.0</version>
 		</dependency>
 		<dependency>
 			<groupId>javax.servlet</groupId>

--- a/src/main/java/com/researchspace/core/util/XMLReadWriteUtils.java
+++ b/src/main/java/com/researchspace/core/util/XMLReadWriteUtils.java
@@ -122,6 +122,8 @@ public class XMLReadWriteUtils {
 			SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
 			sf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
 			sf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			sf.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+			sf.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
 			Schema schema = sf.newSchema(schemaFile);
 			unmarshaller.setSchema(schema);
 			if (eventHandler != null) {

--- a/src/main/java/com/researchspace/core/util/XMLReadWriteUtils.java
+++ b/src/main/java/com/researchspace/core/util/XMLReadWriteUtils.java
@@ -22,6 +22,7 @@ import javax.xml.bind.ValidationEventHandler;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;
+import javax.xml.parsers.SAXParserFactory;
 import javax.xml.transform.OutputKeys;
 import javax.xml.transform.Result;
 import javax.xml.transform.Source;
@@ -31,6 +32,7 @@ import javax.xml.transform.TransformerException;
 import javax.xml.transform.TransformerFactory;
 import javax.xml.transform.TransformerFactoryConfigurationError;
 import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.sax.SAXSource;
 import javax.xml.transform.stream.StreamResult;
 import javax.xml.transform.stream.StreamSource;
 import javax.xml.validation.Schema;
@@ -41,7 +43,9 @@ import org.apache.commons.lang3.Validate;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
+import org.xml.sax.InputSource;
 import org.xml.sax.SAXException;
+import org.xml.sax.XMLReader;
 
 
 /**
@@ -75,16 +79,23 @@ public class XMLReadWriteUtils {
 		logger.debug("StringWriter content: {}", sw.toString());
 		logger.debug("sw to string is: {}", ArrayUtils.toString(sw.toString().getBytes()));
 		try (FileOutputStream fos = new FileOutputStream(ouF)) {
-			TransformerFactory factory = TransformerFactory.newInstance();
-			Transformer transformer = factory.newTransformer();
-			transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-			transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+			Transformer transformer = configureTransformer();
 
 			StreamResult result = new StreamResult(fos);
 
 			transformer.transform(new StreamSource(new StringReader(sw.toString())), result);
 			fos.flush();
 		}
+	}
+
+	private static Transformer configureTransformer() throws TransformerConfigurationException {
+		TransformerFactory factory = TransformerFactory.newInstance();
+		factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+		factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_STYLESHEET, "");
+		Transformer transformer = factory.newTransformer();
+		transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+		transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+		return transformer;
 	}
 
 	/**
@@ -104,9 +115,6 @@ public class XMLReadWriteUtils {
 	public static <T> T fromXML(File xmlFile, Class<T> clazz, File schemaFile, ValidationEventHandler eventHandler)
 			throws JAXBException, SAXException, FileNotFoundException {
 
-		Source source;
-		source = new StreamSource(new BufferedInputStream(new FileInputStream(xmlFile)));
-
 		JAXBContext jc = JAXBContext.newInstance(clazz);
 		Unmarshaller unmarshaller = jc.createUnmarshaller();
 
@@ -120,7 +128,18 @@ public class XMLReadWriteUtils {
 				unmarshaller.setEventHandler(eventHandler);
 			}
 		}
-		return (T) unmarshaller.unmarshal(source);
+
+		SAXParserFactory spf = SAXParserFactory.newInstance();
+		spf.setNamespaceAware(true);
+		try {
+			spf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+			spf.setXIncludeAware(false);
+			XMLReader xmlReader = spf.newSAXParser().getXMLReader();
+			Source source = new SAXSource(xmlReader, new InputSource(new BufferedInputStream(new FileInputStream(xmlFile))));
+			return (T) unmarshaller.unmarshal(source);
+		} catch (ParserConfigurationException e) {
+			throw new SAXException("Error configuring SAX parser", e);
+		}
 	}
 
 	public static <T> void generateSchemaFromXML(File outFile, Class<T> clazz) throws JAXBException, IOException {
@@ -144,6 +163,9 @@ public class XMLReadWriteUtils {
 
 		// Create the Document
 		DocumentBuilderFactory dbf = DocumentBuilderFactory.newInstance();
+		dbf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
+		dbf.setXIncludeAware(false);
+
 		DocumentBuilder db = dbf.newDocumentBuilder();
 		Document document = db.newDocument();
 
@@ -170,9 +192,7 @@ public class XMLReadWriteUtils {
 			throws TransformerFactoryConfigurationError, TransformerException, FileNotFoundException {
 		Validate.noNullElements(new Object[] { document, outStream },
 				format("Arguments cannot be null but were: " + document + ", " + outStream));
-		Transformer transformer = TransformerFactory.newInstance().newTransformer();
-		transformer.setOutputProperty(OutputKeys.INDENT, "yes");
-		transformer.setOutputProperty("{http://xml.apache.org/xslt}indent-amount", "4");
+		Transformer transformer = configureTransformer();
 		StreamResult streamResult = new StreamResult(outStream);
 		DOMSource domSource = new DOMSource(document);
 		transformer.transform(domSource, streamResult);

--- a/src/main/java/com/researchspace/core/util/XMLReadWriteUtils.java
+++ b/src/main/java/com/researchspace/core/util/XMLReadWriteUtils.java
@@ -38,6 +38,8 @@ import javax.xml.validation.SchemaFactory;
 
 import org.apache.commons.lang3.ArrayUtils;
 import org.apache.commons.lang3.Validate;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 import org.w3c.dom.Document;
 import org.xml.sax.SAXException;
 
@@ -46,6 +48,7 @@ import org.xml.sax.SAXException;
  * Useful utility methods for writing XML files
  */
 public class XMLReadWriteUtils {
+	private static final Logger logger = LoggerFactory.getLogger(XMLReadWriteUtils.class);
 
 	/**
 	 * Marshalls the specified class to XML
@@ -69,8 +72,8 @@ public class XMLReadWriteUtils {
 	// this seems to be a bug in xalan 2.7.2 which has not been fixed. 
 	private static void writeFormattedXML(File ouF, StringWriter sw) throws FileNotFoundException,
 			TransformerFactoryConfigurationError, TransformerConfigurationException, TransformerException, IOException {
-		System.err.println(sw.toString());
-		System.err.println("sw to string is :" + ArrayUtils.toString(sw.toString().getBytes()));
+		logger.debug("StringWriter content: {}", sw.toString());
+		logger.debug("sw to string is: {}", ArrayUtils.toString(sw.toString().getBytes()));
 		try (FileOutputStream fos = new FileOutputStream(ouF)) {
 			TransformerFactory factory = TransformerFactory.newInstance();
 			Transformer transformer = factory.newTransformer();
@@ -109,17 +112,15 @@ public class XMLReadWriteUtils {
 
 		if (schemaFile != null) {
 			SchemaFactory sf = SchemaFactory.newInstance(XMLConstants.W3C_XML_SCHEMA_NS_URI);
-			sf.setProperty(XMLConstants.ACCESS_EXTERNAL_DTD, "");
-			sf.setProperty(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+			sf.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+			sf.setFeature("http://apache.org/xml/features/disallow-doctype-decl", true);
 			Schema schema = sf.newSchema(schemaFile);
 			unmarshaller.setSchema(schema);
 			if (eventHandler != null) {
 				unmarshaller.setEventHandler(eventHandler);
 			}
 		}
-		T adc = (T) unmarshaller.unmarshal(source);
-		return adc;
-
+		return (T) unmarshaller.unmarshal(source);
 	}
 
 	public static <T> void generateSchemaFromXML(File outFile, Class<T> clazz) throws JAXBException, IOException {

--- a/src/test/java/com/researchspace/core/util/XMLReadWriteUtilsTest.java
+++ b/src/test/java/com/researchspace/core/util/XMLReadWriteUtilsTest.java
@@ -11,21 +11,12 @@ import java.io.File;
 import java.nio.charset.Charset;
 
 import javax.xml.bind.UnmarshalException;
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlElement;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.w3c.dom.Document;
-
-import lombok.AllArgsConstructor;
-import lombok.Data;
-import lombok.NoArgsConstructor;
 
 public class XMLReadWriteUtilsTest {
 	private static final String TEST_XML_ROOT_OBJECT_ELEMENT_NAME = "testXMLRootObject";
@@ -77,7 +68,7 @@ public class XMLReadWriteUtilsTest {
 	public void roundTripWithInvalidSchemaThrowsUnmarshalException() throws Exception {
 		TestXMLRootObject af = new TestXMLRootObject(1L, "y");
 		XMLReadWriteUtils.toXML(tmpFile, af, TestXMLRootObject.class);
-		File invalidSchema = getResource("zipSchema.xsd");
+		File invalidSchema = new File("src/test/resources/zipSchema.xsd");
 		assertThrows(UnmarshalException.class, ()->XMLReadWriteUtils.fromXML(tmpFile, TestXMLRootObject.class, invalidSchema, null));
 	}
 	
@@ -95,31 +86,25 @@ public class XMLReadWriteUtilsTest {
 		Document doc = XMLReadWriteUtils.convertObjectToW3CDocument(toConvert, TestXMLRootObject.class);
 		try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
 			XMLReadWriteUtils.writeFormattedXML(doc, baos);
-			String output = new String(baos.toByteArray(), Charset.defaultCharset());
+			String output = baos.toString(Charset.defaultCharset());
 			assertTrue (output.contains(TEST_XML_ROOT_OBJECT_ELEMENT_NAME));
 		}
 		
 	}
-	@XmlType()
-	@XmlRootElement
-	@XmlAccessorType(XmlAccessType.FIELD)
-	@AllArgsConstructor
-	@NoArgsConstructor
-	@Data
-	static class XFoo {
-		@XmlElement
-		private String foo;
-	}
+	@Test
+	public void fromXMLWithDocTypeThrowsException() throws Exception {
+		String xxeXml = "<?xml version=\"1.0\" encoding=\"UTF-8\"?>\n" +
+						"<!DOCTYPE testXMLRootObject>\n" +
+						"<testXMLRootObject id=\"1\">\n" +
+						"  <data>&xxe;</data>\n" +
+						"</testXMLRootObject>";
+		FileUtils.writeStringToFile(tmpFile, xxeXml, Charset.defaultCharset());
+		
+		UnmarshalException exception = assertThrows(UnmarshalException.class, () -> {
+			XMLReadWriteUtils.fromXML(tmpFile, TestXMLRootObject.class, null, null);
+		});
 
-	/**
-	 * GEts a test file, specified by its name.
-	 * 
-	 * @param fileName
-	 * @return
-	 */
-	static File getResource(String fileName) {
-		File resource = new File("src/test/resources/" + fileName);
-		return resource;
+		assertTrue(exception.toString().contains("DOCTYPE is disallowed when the feature " +
+						"\"http://apache.org/xml/features/disallow-doctype-decl\" set to true."));
 	}
-
 }


### PR DESCRIPTION
This PR contains changes required to XML parsing to adhere to OWASPs recommendations for safe XML parsing https://cheatsheetseries.owasp.org/cheatsheets/XML_External_Entity_Prevention_Cheat_Sheet.html

The main change is for each XML reader and writer to disallow DTDs. I've followed the strictest guildelines by disallowing these, but if we think there are cases where they can be used, we can change some params to make parsing less strict but still compliant. 

Also tidied up some code, and bumped google zxing(used for barcodes) library version.