### PR TITLE
RSDEV-1062: Adding new global prefixes for Inventory `Instrument` and `InstrumentTemplate`

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,8 @@
 ## Changelog
 
+## 1.2.0 2026-05-15
+- adding global prefixes support for Instrument and InstrumentTemplate
+
 ## 1.1.0 2026-01-26
 - switch to parent-pom 2.1.3
 - harden XML parsing to avoid XXE attacks

--- a/pom.xml
+++ b/pom.xml
@@ -4,7 +4,7 @@
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>rspace-core-util</artifactId>
-	<version>1.1.0</version>
+	<version>1.2.0</version>
 	<name>rspace-core-util</name>
 	<description>Core utility classes</description>
 

--- a/src/main/java/com/researchspace/model/core/GlobalIdPrefix.java
+++ b/src/main/java/com/researchspace/model/core/GlobalIdPrefix.java
@@ -69,7 +69,7 @@ public enum GlobalIdPrefix {
 	/** Inventory SubSample */
 	SS,
 
-	/** SampleField */
+	/** Inventory Field */
 	SF,
 	
 	/** Extra (ad-hoc) Field */
@@ -87,6 +87,12 @@ public enum GlobalIdPrefix {
 	/** (Inventory) File */
 	IF,
 	
+	/** (Inventory) Instrument */
+	IN,
+
+	/** (Inventory) InstrumentTemplate */
+	NT,
+
 	/** List of Materials */
 	LM,
 	


### PR DESCRIPTION
## Parent PRs ##
 - `rspace-web`: https://github.com/rspace-os/rspace-web/pull/726
 - `rspace-core-model`: https://github.com/rspace-os/rspace-core-model/pull/62
 - `rspace-audit`: https://github.com/rspace-os/rspace-audit/pull/4
