### PR TITLE
RSDEV-444: Upgrade rspace-core-util to 2.0.0

### DIFF
--- a/Changelog.md
+++ b/Changelog.md
@@ -1,6 +1,6 @@
 ## Changelog
 
-## 2.0.0 2026-04-29
+## 2.0.0 2026-07-28
 - Spring 6 / Hibernate 6 / Jakarta namespace migration
 - Switch to rspace-parent 3.0.0
 

--- a/Changelog.md
+++ b/Changelog.md
@@ -1,5 +1,9 @@
 ## Changelog
 
+## 2.0.0 2026-04-29
+- Spring 6 / Hibernate 6 / Jakarta namespace migration
+- Switch to rspace-parent 3.0.0
+
 ## 1.1.0 2026-01-26
 - switch to parent-pom 2.1.3
 - harden XML parsing to avoid XXE attacks

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<artifactId>rspace-parent</artifactId>
 		<groupId>com.github.rspace-os</groupId>
-		<version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
+		<version>3.0.0</version>
 	</parent>
 
 	<repositories>

--- a/pom.xml
+++ b/pom.xml
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>com.github.rspace-os</groupId>
 			<artifactId>rspace-test-util</artifactId>
-			<version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
+			<version>3.0.0</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
 	<parent>
 		<artifactId>rspace-parent</artifactId>
 		<groupId>com.github.rspace-os</groupId>
-		<version>3.0.0</version>
+		<version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
 	</parent>
 
 	<repositories>
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>com.github.rspace-os</groupId>
 			<artifactId>rspace-test-util</artifactId>
-			<version>3.0.0</version>
+			<version>rsdev-444-upgrade-to-spring-6-SNAPSHOT</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>

--- a/pom.xml
+++ b/pom.xml
@@ -4,14 +4,14 @@
 
 	<modelVersion>4.0.0</modelVersion>
 	<artifactId>rspace-core-util</artifactId>
-	<version>1.1.0</version>
+	<version>2.0.0</version>
 	<name>rspace-core-util</name>
 	<description>Core utility classes</description>
 
 	<parent>
 		<artifactId>rspace-parent</artifactId>
 		<groupId>com.github.rspace-os</groupId>
-		<version>2.1.3</version>
+		<version>3.0.0</version>
 	</parent>
 
 	<repositories>
@@ -38,7 +38,7 @@
 		<dependency>
 			<groupId>com.github.rspace-os</groupId>
 			<artifactId>rspace-test-util</artifactId>
-			<version>2.0.4</version>
+			<version>3.0.0</version>
 			<scope>test</scope>
 			<exclusions>
 				<exclusion>
@@ -59,9 +59,9 @@
 			<version>1.4.0</version>
 		</dependency>
 		<dependency>
-			<groupId>javax.servlet</groupId>
-			<artifactId>javax.servlet-api</artifactId>
-			<version>3.0.1</version>
+			<groupId>jakarta.servlet</groupId>
+			<artifactId>jakarta.servlet-api</artifactId>
+			<version>6.1.0</version>
 			<scope>provided</scope>
 		</dependency>
 		<dependency>
@@ -128,8 +128,8 @@
 			</exclusions>
 		</dependency>
 		<dependency>
-			<groupId>javax.xml.bind</groupId>
-			<artifactId>jaxb-api</artifactId>
+			<groupId>jakarta.xml.bind</groupId>
+			<artifactId>jakarta.xml.bind-api</artifactId>
 		</dependency>
 		<dependency>
 			<groupId>org.glassfish.jaxb</groupId>

--- a/src/main/java/com/researchspace/core/util/RequestUtil.java
+++ b/src/main/java/com/researchspace/core/util/RequestUtil.java
@@ -1,9 +1,9 @@
 package com.researchspace.core.util;
 
-import javax.servlet.ServletRequest;
-import javax.servlet.http.Cookie;
-import javax.servlet.http.HttpServletRequest;
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.ServletRequest;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.apache.commons.lang3.StringUtils;
 import org.slf4j.Logger;

--- a/src/main/java/com/researchspace/core/util/ResponseUtil.java
+++ b/src/main/java/com/researchspace/core/util/ResponseUtil.java
@@ -2,7 +2,7 @@ package com.researchspace.core.util;
 
 import java.util.Date;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 /**
  * Utility methods for manipulating the HTTP response directly

--- a/src/main/java/com/researchspace/core/util/SecureStringUtils.java
+++ b/src/main/java/com/researchspace/core/util/SecureStringUtils.java
@@ -6,7 +6,7 @@ import org.apache.shiro.crypto.RandomNumberGenerator;
 import org.apache.shiro.crypto.SecureRandomNumberGenerator;
 import org.apache.shiro.crypto.hash.Hash;
 import org.apache.shiro.crypto.hash.Sha256Hash;
-import org.apache.shiro.util.ByteSource;
+import org.apache.shiro.lang.util.ByteSource;
 
 /**
  * Utility class for methods for generating secure random Strings

--- a/src/main/java/com/researchspace/core/util/XMLReadWriteUtils.java
+++ b/src/main/java/com/researchspace/core/util/XMLReadWriteUtils.java
@@ -13,12 +13,12 @@ import java.io.StringReader;
 import java.io.StringWriter;
 
 import javax.xml.XMLConstants;
-import javax.xml.bind.JAXBContext;
-import javax.xml.bind.JAXBException;
-import javax.xml.bind.Marshaller;
-import javax.xml.bind.SchemaOutputResolver;
-import javax.xml.bind.Unmarshaller;
-import javax.xml.bind.ValidationEventHandler;
+import jakarta.xml.bind.JAXBContext;
+import jakarta.xml.bind.JAXBException;
+import jakarta.xml.bind.Marshaller;
+import jakarta.xml.bind.SchemaOutputResolver;
+import jakarta.xml.bind.Unmarshaller;
+import jakarta.xml.bind.ValidationEventHandler;
 import javax.xml.parsers.DocumentBuilder;
 import javax.xml.parsers.DocumentBuilderFactory;
 import javax.xml.parsers.ParserConfigurationException;

--- a/src/test/java/com/researchspace/core/util/RequestUtilsTest.java
+++ b/src/test/java/com/researchspace/core/util/RequestUtilsTest.java
@@ -5,7 +5,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.Mockito.when;
 
-import javax.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletRequest;
 
 import org.junit.Rule;
 import org.junit.Test;

--- a/src/test/java/com/researchspace/core/util/ResponseUtilsTest.java
+++ b/src/test/java/com/researchspace/core/util/ResponseUtilsTest.java
@@ -2,7 +2,7 @@ package com.researchspace.core.util;
 
 import java.util.Date;
 
-import javax.servlet.http.HttpServletResponse;
+import jakarta.servlet.http.HttpServletResponse;
 
 import org.junit.After;
 import org.junit.Before;

--- a/src/test/java/com/researchspace/core/util/TestXMLNonRootObject.java
+++ b/src/test/java/com/researchspace/core/util/TestXMLNonRootObject.java
@@ -1,7 +1,7 @@
 package com.researchspace.core.util;
 
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlType;
 
 @XmlType()
 class TestXMLNonRootObject {

--- a/src/test/java/com/researchspace/core/util/TestXMLRootObject.java
+++ b/src/test/java/com/researchspace/core/util/TestXMLRootObject.java
@@ -1,10 +1,10 @@
 package com.researchspace.core.util;
 
-import javax.xml.bind.annotation.XmlAccessType;
-import javax.xml.bind.annotation.XmlAccessorType;
-import javax.xml.bind.annotation.XmlAttribute;
-import javax.xml.bind.annotation.XmlRootElement;
-import javax.xml.bind.annotation.XmlType;
+import jakarta.xml.bind.annotation.XmlAccessType;
+import jakarta.xml.bind.annotation.XmlAccessorType;
+import jakarta.xml.bind.annotation.XmlAttribute;
+import jakarta.xml.bind.annotation.XmlRootElement;
+import jakarta.xml.bind.annotation.XmlType;
 
 import lombok.AllArgsConstructor;
 import lombok.Data;

--- a/src/test/java/com/researchspace/core/util/XMLReadWriteUtilsTest.java
+++ b/src/test/java/com/researchspace/core/util/XMLReadWriteUtilsTest.java
@@ -10,7 +10,7 @@ import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.nio.charset.Charset;
 
-import javax.xml.bind.UnmarshalException;
+import jakarta.xml.bind.UnmarshalException;
 
 import org.apache.commons.io.FileUtils;
 import org.junit.jupiter.api.AfterEach;


### PR DESCRIPTION
Upgrade rspace-core-util to 2.0.0 for Spring 6 / Jakarta namespace migration (RSDEV-444).

Migrates servlet and JAXB imports from `javax.*` to `jakarta.*` and switches Shiro's `ByteSource` to its 2.x relocated package.

---

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
